### PR TITLE
feat(ui): completar dashboard admin con métricas, tabla de citas y logs

### DIFF
--- a/ui-admin-dashboard.html
+++ b/ui-admin-dashboard.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="es" data-bs-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dashboard – MedSchedule</title>
+</head>
+<script type="module" src="/@vite/client"></script>
+<script type="module" src="/resources/js/app.js"></script>
+<body>
+  <!-- Navbar mínima para navegar -->
+  <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom">
+    <div class="container">
+      /index.htmlMedSchedule</a>
+      <div class="collapse navbar-collapse show" id="nav">
+        <ul class="navbar-nav ms-auto gap-3">
+          <li class="nav-item">/ui-login.htmlLogin</a></li>
+          <li class="nav-item">/ui-about.htmlAbout</a></li>
+          <li class="nav-item">/ui-admin-dashboard.htmlDashboard</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <main class="container py-4">
+    <!-- (PEGA AQUÍ el contenido del dashboard que ya tienes) -->
+    <!-- ejemplo de primera sección -->
+    <div class="d-flex flex-wrap align-items-center justify-content-between mb-3">
+      <h1 class="h4 m-0">Dashboard Administrador</h1>
+      <div class="d-flex gap-2 mt-2 mt-sm-0">
+        <select class="form-select form-select-sm" style="min-width: 180px;">
+          <option value="hoy">Hoy</option>
+          <option value="semana">Últimos 7 días</option>
+          <option value="mes">Últimos 30 días</option>
+        </select>
+        <button class="btn btn-sm btn-outline-secondary">/ui-admin-dashboard.htmlActualizar</a></button>
+      </div>
+    </div>
+
+    <!-- (Resto de tarjetas, tabla y logs que ya tenías) -->
+     <!-- Tarjetas de métricas -->
+<div class="row g-3 mb-4">
+  <div class="col-12 col-sm-6 col-lg-3">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="text-muted small">Citas de hoy</div>
+            <div class="fs-4 fw-semibold">32</div>
+          </div>
+          <span class="badge text-bg-primary">+8%</span>
+        </div>
+        <div class="small text-muted mt-2">Comparado con ayer</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-sm-6 col-lg-3">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="text-muted small">Usuarios totales</div>
+            <div class="fs-4 fw-semibold">1,254</div>
+          </div>
+          <span class="badge text-bg-secondary">+2%</span>
+        </div>
+        <div class="small text-muted mt-2">Activos este mes</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-sm-6 col-lg-3">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="text-muted small">Doctores activos</div>
+            <div class="fs-4 fw-semibold">18</div>
+          </div>
+          <span class="badge text-bg-success">OK</span>
+        </div>
+        <div class="small text-muted mt-2">Con agenda disponible</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-sm-6 col-lg-3">
+    <div class="card shadow-sm h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="text-muted small">Cancelaciones</div>
+            <div class="fs-4 fw-semibold">6</div>
+          </div>
+          <span class="badge text-bg-danger">-</span>
+        </div>
+        <div class="small text-muted mt-2">Hoy</div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- Grid principal -->
+<div class="row g-3">
+  <!-- Tabla de citas recientes -->
+  <div class="col-12 col-xl-8">
+    <div class="card shadow-sm h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span class="fw-semibold">Citas recientes</span>
+        <div class="input-group input-group-sm" style="max-width: 260px;">
+          <span class="input-group-text">Buscar</span>
+          <input type="text" class="form-control" placeholder="Paciente, doctor, estado..." />
+        </div>
+      </div>
+
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-sm table-hover align-middle mb-0">
+            <thead class="table-light">
+              <tr>
+                <th>#</th>
+                <th>Paciente</th>
+                <th>Doctor</th>
+                <th>Fecha</th>
+                <th>Hora</th>
+                <th>Estado</th>
+                <th class="text-end">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1024</td>
+                <td>María López</td>
+                <td>Dr. Rivera</td>
+                <td>2026-02-23</td>
+                <td>10:30</td>
+                <td><span class="badge text-bg-warning">Pendiente</span></td>
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-primary">Ver</button>
+                </td>
+              </tr>
+              <tr>
+                <td>1023</td>
+                <td>Carlos Méndez</td>
+                <td>Dr. Juárez</td>
+                <td>2026-02-23</td>
+                <td>09:00</td>
+                <td><span class="badge text-bg-success">Confirmada</span></td>
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-primary">Ver</button>
+                </td>
+              </tr>
+              <tr>
+                <td>1022</td>
+                <td>Lucía Torres</td>
+                <td>Dra. Gómez</td>
+                <td>2026-02-23</td>
+                <td>08:15</td>
+                <td><span class="badge text-bg-danger">Cancelada</span></td>
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-primary">Ver</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card-footer d-flex justify-content-between align-items-center">
+        <span class="small text-muted">Mostrando 3 de 50</span>
+        <nav aria-label="Paginación de citas">
+          <ul class="pagination pagination-sm m-0">
+            <li class="page-item disabled">/ui-admin-dashboard.htmlAnterior</a></li>
+            <li class="page-item active">/ui-admin-dashboard.html1</a></li>
+            <li class="page-item">/ui-admin-dashboard.html2</a></li>
+            <li class="page-item">/ui-admin-dashboard.html3</a></li>
+            <li class="page-item">/ui-admin-dashboard.htmlSiguiente</a></li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+
+  <!-- Panel de logs -->
+  <div class="col-12 col-xl-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span class="fw-semibold">Logs del sistema</span>
+        <button class="btn btn-sm btn-outline-secondary">/ui-admin-dashboard.htmlRefrescar</a></button>
+      </div>
+      <div class="card-body">
+        <ul class="list-group list-group-flush small">
+          <li class="list-group-item px-0">[10:02] Admin creó usuario: <code>jcalles</code></li>
+          <li class="list-group-item px-0">[09:57] Doctor <code>dr.rivera</code> confirmó cita #1023</li>
+          <li class="list-group-item px-0">[09:30] Paciente <code>mlopez</code> solicitó cita</li>
+          <li class="list-group-item px-0">[08:12] Sistema envió email de reset a <code>ctorres</code></li>
+        </ul>
+      </div>
+      <div class="card-footer text-end">
+        #Ver todos</a>
+      </div>
+    </div>
+  </div>
+</div>
+    <!-- ... -->
+  </main>
+
+
+</body>
+</html>
+``

--- a/ui-layout.html
+++ b/ui-layout.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<li class="nav-item">/ui-admin-dashboard.htmlDashboard</a></li>
 <html lang="es" data-bs-theme="light">
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
 Tarjetas KPI: citas de hoy, usuarios totales, doctores activos, cancelaciones.
- Tabla de "Citas recientes" con badges de estado y paginación.
- Panel de "Logs del sistema".
- Ajuste de ui-layout (navbar y scripts de Vite).
- Probado localmente en http://localhost:5173/ui-admin-dashboard.html